### PR TITLE
docs(manifest): update application name to "Linkorg"

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Link Organizer",
+  "name": "Linkorg",
   "short_name": "Links",
   "start_url": "/",
   "display": "standalone",


### PR DESCRIPTION
The application name in the manifest.json file was changed from "Link Organizer" to "Linkorg" to align with the branding strategy and provide a more concise and memorable name.